### PR TITLE
Fix deprecated: implode(): Passing glue string after array is depreca…

### DIFF
--- a/src/ChunkDecoder/PresentWeatherChunkDecoder.php
+++ b/src/ChunkDecoder/PresentWeatherChunkDecoder.php
@@ -24,8 +24,8 @@ class PresentWeatherChunkDecoder extends MetarChunkDecoder implements MetarChunk
 
     public function getRegexp()
     {
-        $carac_regexp = implode(self::$carac_dic, '|');
-        $type_regexp = implode(self::$type_dic, '|');
+        $carac_regexp = implode('|', self::$carac_dic);
+        $type_regexp = implode('|', self::$type_dic);
         $pw_regexp = "([-+]|VC)?($carac_regexp)?($type_regexp)?($type_regexp)?($type_regexp)?";
 
         return "#^($pw_regexp )?($pw_regexp )?($pw_regexp )?()?#";

--- a/src/ChunkDecoder/RecentWeatherChunkDecoder.php
+++ b/src/ChunkDecoder/RecentWeatherChunkDecoder.php
@@ -11,8 +11,8 @@ class RecentWeatherChunkDecoder extends MetarChunkDecoder implements MetarChunkD
 {
     public function getRegexp()
     {
-        $carac_regexp = implode(PresentWeatherChunkDecoder::$carac_dic, '|');
-        $type_regexp = implode(PresentWeatherChunkDecoder::$type_dic, '|');
+        $carac_regexp = implode('|', PresentWeatherChunkDecoder::$carac_dic);
+        $type_regexp = implode('|', PresentWeatherChunkDecoder::$type_dic);
 
         return "#^RE($carac_regexp)?($type_regexp)?($type_regexp)?($type_regexp)?()? #";
     }


### PR DESCRIPTION
…ted.